### PR TITLE
POD fix Tk::Text

### DIFF
--- a/pod/Text.pod
+++ b/pod/Text.pod
@@ -330,13 +330,13 @@ Adjust the index to refer to the character just after the last one of the
 word containing the current index.  If the current index refers to the last
 character of the text then it is not modified.
 
+=back
+
 If more than one modifier is present then they are applied in
 left-to-right order.  For example, the index ``B<end - 1 chars>''
 refers to the next-to-last character in the text and
 ``B<insert wordstart - 1 c>'' refers to the character just before
 the first one in the word containing the insertion cursor.
-
-=back
 
 =head1 TAGS
 


### PR DESCRIPTION
Trivial formatting patch, because I was confused in L<Tk::Text POD/INDICES>, by the absence of separation between base & modifier descriptions.
