### PR TITLE
Create ErrorDialog.pod

### DIFF
--- a/pod/ErrorDialog.pod
+++ b/pod/ErrorDialog.pod
@@ -1,0 +1,36 @@
+#  Copyright (c) 1990-1994 The Regents of the University of California.
+#  Copyright (c) 1994-1996 Sun Microsystems, Inc.
+#  See the file "license.terms" for information on usage and redistribution
+#  of this file, and for a DISCLAIMER OF ALL WARRANTIES.
+#
+#
+
+=head1 NAME
+
+Tk::ErrorDialog - Method invoked to process background errors
+
+=for category Binding Events and Callbacks
+
+=head1 SYNOPSIS
+
+Customization:
+
+    require Tk::ErrorDialog;
+
+=head1 DESCRIPTION
+
+C<Tk::ErrorDialog> is a possibility to handle background errors. For a full descriptionm, see L<Tk::Error>.
+
+=head1 SEE ALSO
+
+L<Tk::Error>
+L<Tk::bind|Tk::bind>
+L<Tk::after|Tk::after>
+L<Tk::fileevent|Tk::fileevent>
+
+=head1 KEYWORDS
+
+background error, reporting, error dialog
+
+=cut
+


### PR DESCRIPTION
In the list of Tk modules, there is Tk::ErrorDialog. Also, when users will handle errors using Tk::ErrorDialog, they will put a use Tk::ErrorDialog statement in their code. But no documentation for Tk/ErrorDialog.pm can be found. Instead, someone has to search and find Tk::Error.
Yes, it's not that far away :)
But here is a proposal how some documentation could look like to point at least to Tk::Error.
