### PR TITLE
Teach perl/Tk where OS X Yosemite Xquartz puts the X11 files

### DIFF
--- a/myConfig
+++ b/myConfig
@@ -365,7 +365,8 @@ if ($win_arch eq 'x') {
   #
   unless (defined $xlib)
     {
-      $xlib = &lX11(0,chooseX11(</usr/X11*/lib>),chooseX11(</usr/lib/X11*>),</usr/Xfree*/lib>,'/usr/X386/lib')
+      $xlib = &lX11(0,chooseX11(</usr/X11*/lib>),chooseX11(</usr/lib/X11*>),</usr/Xfree*/lib>,'/usr/X386/lib',
+                    '/opt/X11/lib')
     }
 
   #


### PR DESCRIPTION
X11 files now live in /opt/X11 and the system /usr/ tree no longer has a
residual soft link to that location (as was the case with Mavericks).
