### PR TITLE
Added library name to zlib.def file

### DIFF
--- a/PNG/imgPNG.c
+++ b/PNG/imgPNG.c
@@ -27,7 +27,7 @@
 #ifdef HAVE_IMG_H
 #   include <png.h>
 #else
-#   include "png.h"
+#   include "libpng/png.h"
 #endif
 #endif
 

--- a/PNG/zlib/win32/zlib.def
+++ b/PNG/zlib/win32/zlib.def
@@ -1,4 +1,4 @@
-LIBRARY
+LIBRARY Z
 ; zlib data compression library
 
 EXPORTS


### PR DESCRIPTION
First, thank you for maintaining. Since I use this in a Windows environment and it is failing to build for Windows under Active State I felt it was only right to contribute. Looks like ' Z' was left out of the first line of zlib.def. I tried to build it but got a new error and i'm not sure if it's due to environment or real error. I'll try to track it down but in the mean time...

c:/perl64/site/lib/auto/mingw/bin/../lib/gcc/x86_64-w64-mingw32/4.5.4/../../../../x86_64-w
64-mingw32/bin/ld.exe: libpng.a(pngread.o): bad reloc address 0x308 in section `.rdata'
c:/perl64/site/lib/auto/mingw/bin/../lib/gcc/x86_64-w64-mingw32/4.5.4/../../../../x86_64-w
64-mingw32/bin/ld.exe: final link failed: Invalid operation
collect2: ld returned 1 exit status
dmake.exe:  Error code 129, while making 'pngtest'
dmake.exe:  Error code 255, while making 'subdirs'
dmake.exe:  Error code 255, while making 'subdirs' 