### PR TITLE
fixed link to getOpenFile

### DIFF
--- a/Tk.pod
+++ b/Tk.pod
@@ -392,7 +392,7 @@ L<Tk::FileSelect|Tk::FileSelect>
 
 =item *
 
-L<Tk::getOpenFile|Tk::getOpenFile>
+L<Tk::getOpenFile|getOpenFile>
 
 =item *
 


### PR DESCRIPTION
The link to getOpenFile() for the file selection dialog pointed to Tk::getOpenFile. However, you have to search for getOpenFile without the Tk namespace.
