### PR TITLE
menu demos: use empty string to clear $status_bar

### DIFF
--- a/demos/demos/widget_lib/menus.pl
+++ b/demos/demos/widget_lib/menus.pl
@@ -173,8 +173,8 @@ sub menus {
         -font => 'Helvetica 10', -textvariable => \$status_bar)->
 	pack(qw/-padx 2 -pady 2 -expand yes -fill both/);
     $menubar->bind('<<MenuSelect>>' => sub {
-	$status_bar = undef;
-	$status_bar = $_[0]->entrycget('active', -label);
+	my $entry = shift;
+	$status_bar = $entry->entrycget('active', -label) || '';
 	$TOP->idletasks;
     });
 

--- a/demos/demos/widget_lib/menus2.pl
+++ b/demos/demos/widget_lib/menus2.pl
@@ -192,8 +192,8 @@ sub menus2 {
         -font => 'Helvetica 10', -textvariable => \$status_bar)->
 	pack(qw/-padx 2 -pady 2 -expand yes -fill both/);
     $menubar->bind('<<MenuSelect>>' => sub {
-	$status_bar = undef;
-	$status_bar = $_[0]->entrycget('active', -label);
+	my $entry = shift;
+	$status_bar = $entry->entrycget('active', -label) || '';
 	$TOP->idletasks;
     });
 


### PR DESCRIPTION
Under Tcl::pTk, using `undef` instead of an empty string to clear `$status_bar` (the textvariable for the status bar label) can cause a "Use of uninitialized value in subroutine entry" warning.

I haven't seen this warning under Perl/Tk, but am providing this for consistency. I don't know whether a label should support textvariable being set to `undef` and act the same as when set to empty string.