### PR TITLE
scrolling improvements for aqua

### DIFF
--- a/Tk/Widget.pm
+++ b/Tk/Widget.pm
@@ -1106,7 +1106,9 @@ sub MouseWheelBind
  # events on other platforms.
 
  $mw->Tk::bind($class, '<MouseWheel>',
-	       [ sub { $_[0]->yview('scroll',-($_[1]/120)*3,'units') }, Tk::Ev("D")]);
+    $mw->windowingsystem eq 'aqua'
+	    ? [ sub { $_[0]->yview('scroll',-($_[1]),'units') }, Tk::Ev("D")]
+	    : [ sub { $_[0]->yview('scroll',-($_[1]/120)*3,'units') }, Tk::Ev("D")]);
 
  if ($Tk::platform eq 'unix')
   {

--- a/Tk/Widget.pm
+++ b/Tk/Widget.pm
@@ -1110,7 +1110,7 @@ sub MouseWheelBind
 	    ? [ sub { $_[0]->yview('scroll',-($_[1]),'units') }, Tk::Ev("D")]
 	    : [ sub { $_[0]->yview('scroll',-($_[1]/120)*3,'units') }, Tk::Ev("D")]);
 
- if ($Tk::platform eq 'unix')
+ if ($mw->windowingsystem eq 'x11')
   {
    # Support for mousewheels on Linux/Unix commonly comes through mapping
    # the wheel to the extended buttons.  If you have a mousewheel, find


### PR DESCRIPTION
Here are two separate commits for supporting scrolling on macOS aqua (cf. #24). These were tested with Tcl::pTk, so I'm assuming they'll be applicable to Perl/Tk.

1. Use the correct scaling factor for MouseWheel event units; see https://rt.cpan.org/Ticket/Display.html?id=125048. Adapted from http://wiki.tcl.tk/3893:

> [Kevin Walzer](http://wiki.tcl.tk/12566) On OS X/Aqua the correct mousewheel binding would be:
>```tcl
>bind .t.c <MouseWheel> {%W yview scroll [expr {- (%D)}] units}
>```

2. Mouse buttons 4 and 5 being used for scrolling is specific to X11, i.e. not all Unix `windowingsystem`s do this (e.g. aqua does not). So instead of assuming X11 by checking `$Tk::Platform`, check `windowingsystem eq 'x11'` instead. This prevents the issue of someone's many-buttoned mouse from causing scroll events on aqua. This also matches the usage in https://core.tcl.tk/tips/doc/trunk/tip/171.md