### PR TITLE
Change more Cursor -> Tk_Cursor to fix exceptions on Strawberry Perl 64-bit

### DIFF
--- a/pTk/mTk/tixGeneric/tixHList.h
+++ b/pTk/mTk/tixGeneric/tixHList.h
@@ -164,7 +164,7 @@ typedef struct HListStruct {
     GC anchorGC;		/* GC for drawing dotted anchor highlight. */
     GC dropSiteGC;		/* GC for drawing dotted anchor highlight. */
 
-    Cursor cursor;		/* Current cursor for window, or None. */
+    Tk_Cursor cursor;		/* Current cursor for window, or None. */
 
     int topPixel;		/* Vertical offset */
     int leftPixel;		/* Horizontal offset */

--- a/pTk/mTk/tixGeneric/tixInputO.c
+++ b/pTk/mTk/tixGeneric/tixInputO.c
@@ -39,7 +39,7 @@ typedef struct Tix_InputOnlyStruct {
     int height;
 
     /* Cursor */
-    Cursor cursor;		/* Current cursor for window, or None. */
+    Tk_Cursor cursor;		/* Current cursor for window, or None. */
     int changed;
 } Tix_InputOnly;
 

--- a/pTk/mTk/tixGeneric/tixNBFrame.c
+++ b/pTk/mTk/tixGeneric/tixNBFrame.c
@@ -79,7 +79,7 @@ typedef struct NoteBookFrameStruct {
 				 * this GC is used to stipple background
 				 * across it.*/
 
-     Cursor cursor;		/* Current cursor for window, or None. */
+    Tk_Cursor cursor;		/* Current cursor for window, or None. */
 
     struct _Tab * tabHead;
     struct _Tab * tabTail;


### PR DESCRIPTION
On Windows Strawberry 64-bit, sizeof(Cursor) is 4 and sizeof(Tk_Cursor) is 8.

Tk_FreeOptions() casts ptr to Tk_Cursor* and dereferences it to compare with None.  If the widget uses Cursor instead of Tk_Cursor then the derefernce will include 4 bytes of adjacent data may erroneously call Tk_FreeCursor with an invalid cursor argument type, leading to panic("Tk_FreeCursor received unknown cursor argument");

This patch fixes some long-standing bugs when destroying HList and Tree objects:
https://rt.cpan.org/Public/Bug/Display.html?id=67889
https://groups.google.com/forum/#!topic/comp.lang.perl.tk/chS7mupl5Hw
http://www.perl-community.de/bat/poard/thread/16244
