### PR TITLE
buttons 4 and 5 scrolling is X11 specific

### DIFF
--- a/Tk/Widget.pm
+++ b/Tk/Widget.pm
@@ -1107,7 +1107,7 @@ sub MouseWheelBind
  $mw->Tk::bind($class, '<MouseWheel>',
 	       [ sub { $_[0]->yview('scroll',-($_[1]/120)*3,'units') }, Tk::Ev("D")]);
 
- if ($Tk::platform eq 'unix')
+ if ($mw->windowingsystem eq 'x11')
   {
    # Support for mousewheels on Linux/Unix commonly comes through mapping
    # the wheel to the extended buttons.  If you have a mousewheel, find


### PR DESCRIPTION
Don't use these buttons for scrolling on non-X11 Unix platforms (e.g. macOS aqua, in the event it is supported). For consistency with Tcl::pTk: https://github.com/chrstphrchvz/perl-tcl-ptk/commit/3d36cc390f8ef4d72c318a9b335b88d067c2be29

There could still be other similar instances; this is just the one taken from #35.