### PR TITLE
table_demo: prevent errors when clicking button

### DIFF
--- a/examples/table_demo
+++ b/examples/table_demo
@@ -31,7 +31,7 @@ sub Pressed
  my ($t,$i,$j) = @_;
  my $l = $t->Label(-text => "Pressed $i,$j",-relief => 'sunken');
  my $old = $t->put($i,$j,$l);
- $old->delete if ($old);
+ $old->destroy if ($old);
 }
 
 my $i;


### PR DESCRIPTION
An error would occur when clicking buttons in the table:

```
Tk::Error: Failed to AUTOLOAD 'Tk::Button::delete' at examples/table_demo line 34.
 Carp::croak at /opt/local/lib/perl5/5.28/Carp.pm line 291
 Tk::Widget::__ANON__ at /opt/local/lib/perl5/vendor_perl/5.28/darwin-thread-multi-2level/Tk/Widget.pm line 347
 main::Pressed at examples/table_demo line 34
 Tk callback for .table.button53
 Tk::__ANON__ at /opt/local/lib/perl5/vendor_perl/5.28/darwin-thread-multi-2level/Tk.pm line 251
 Tk::Button::butUp at /opt/local/lib/perl5/vendor_perl/5.28/darwin-thread-multi-2level/Tk/Button.pm line 175
 <ButtonRelease-1>
 (command bound to event)
```

There is no such widget method `delete`, so my guess is it meant to use `destroy` instead.