### PR TITLE
wm-time.t: prevent uninitialized value warning

### DIFF
--- a/t/wm-time.t
+++ b/t/wm-time.t
@@ -21,6 +21,7 @@ my $mw = new MainWindow;
 
 my %wm_info = wm_info($mw);
 my $wm_name = $wm_info{name};
+$wm_name = '' unless defined $wm_name;
 
 my $initial_ok_delay = 0.4;
 # GNOME Shell is sometimes slow


### PR DESCRIPTION
Prevents a warning observed on Windows:

```
Use of uninitialized value $wm_name in string eq at t\wm-time.t line 27.
```