### PR TITLE
photo1.pl: Prevent blank window when opened

### DIFF
--- a/demos/demos/widget_lib/photo1.pl
+++ b/demos/demos/widget_lib/photo1.pl
@@ -17,14 +17,15 @@ sub photo1 {
 
     my $f1 = $TOP->Photo( -file => Tk->findINC( 'demos/images/teapot.ppm' ) );
     $l->configure( -image => $f1 );
-    $TOP->idletasks;
-    $TOP->after(2000);
+    $TOP->after(2000,
+        sub {
 
-    foreach my $x ( 50 .. 100 ) {
-	foreach my $y ( 50 .. 100 ) {
-	    $f1->transparencySet( $x, $y, 1 );
-	    $f1->update;
-	}
-    }
-
+            foreach my $x ( 50 .. 100 ) {
+            foreach my $y ( 50 .. 100 ) {
+                $f1->transparencySet( $x, $y, 1 );
+                $f1->update;
+            }
+            }
+        },
+    );
 } # end photo1


### PR DESCRIPTION
- Simply calling `after(2000)` blocks events for 2 seconds, and prevents demo from appearing. Instead, rewrite `after()` with a subroutine to update transparency.
- Remove unneeded `idletasks()`.

As done in Tcl::pTk: https://github.com/chrstphrchvz/perl-tcl-ptk/commit/3177cb6