### PR TITLE
Tk/typemap: prevent compiler warnings

### DIFF
--- a/Tk/typemap
+++ b/Tk/typemap
@@ -30,7 +30,7 @@ T_PVOBJ
 	    STRLEN sz;
 	    $var = ($type) SvPV((SV*)SvRV($arg),sz);
 	    if (sz != sizeof(*$var))
-	     croak(\"$arg too small (%d) for $var $type (%d)\",sz,sizeof(*$var));
+	     croak(\"$arg too small (%\"UVuf\") for $var $type (%\"UVuf\")\",sz,sizeof(*$var));
 	}
 	else
 	    croak(\"$var is not an object\")


### PR DESCRIPTION
~~Add casts to `UV`, and~~ use `"%"UVuf` format specifiers instead of `"%d"`, to prevent the following compiler warnings:

```
Tk.c: In function 'XS_Tk__FontRankInfo_encoding':
Tk.c:416:13: warning: format '%d' expects argument of type 'int', but argument 2 has type 'STRLEN' {aka 'long unsigned int'} [-Wformat=]
       croak("ST(0) too small (%d) for p LangFontInfo * (%d)",sz,sizeof(*p));
             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ~~
Tk.c:416:13: warning: format '%d' expects argument of type 'int', but argument 3 has type 'long unsigned int' [-Wformat=]
Tk.c: In function 'XS_Tk__FontRankInfo_foundary':
Tk.c:444:13: warning: format '%d' expects argument of type 'int', but argument 2 has type 'STRLEN' {aka 'long unsigned int'} [-Wformat=]
       croak("ST(0) too small (%d) for p LangFontInfo * (%d)",sz,sizeof(*p));
             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ~~
Tk.c:444:13: warning: format '%d' expects argument of type 'int', but argument 3 has type 'long unsigned int' [-Wformat=]
Tk.c: In function 'XS_Tk__FontRankInfo_Xname':
Tk.c:472:13: warning: format '%d' expects argument of type 'int', but argument 2 has type 'STRLEN' {aka 'long unsigned int'} [-Wformat=]
       croak("ST(0) too small (%d) for p LangFontInfo * (%d)",sz,sizeof(*p));
             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ~~
Tk.c:472:13: warning: format '%d' expects argument of type 'int', but argument 3 has type 'long unsigned int' [-Wformat=]
Tk.c: In function 'XS_Tk__FontRankInfo_family':
Tk.c:500:13: warning: format '%d' expects argument of type 'int', but argument 2 has type 'STRLEN' {aka 'long unsigned int'} [-Wformat=]
       croak("ST(0) too small (%d) for p LangFontInfo * (%d)",sz,sizeof(*p));
             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ~~
Tk.c:500:13: warning: format '%d' expects argument of type 'int', but argument 3 has type 'long unsigned int' [-Wformat=]
Tk.c: In function 'XS_Tk__FontRankInfo_size':
Tk.c:529:13: warning: format '%d' expects argument of type 'int', but argument 2 has type 'STRLEN' {aka 'long unsigned int'} [-Wformat=]
       croak("ST(0) too small (%d) for p LangFontInfo * (%d)",sz,sizeof(*p));
             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ~~
Tk.c:529:13: warning: format '%d' expects argument of type 'int', but argument 3 has type 'long unsigned int' [-Wformat=]
Tk.c: In function 'XS_Tk__FontRankInfo_bold':
Tk.c:556:13: warning: format '%d' expects argument of type 'int', but argument 2 has type 'STRLEN' {aka 'long unsigned int'} [-Wformat=]
       croak("ST(0) too small (%d) for p LangFontInfo * (%d)",sz,sizeof(*p));
             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ~~
Tk.c:556:13: warning: format '%d' expects argument of type 'int', but argument 3 has type 'long unsigned int' [-Wformat=]
Tk.c: In function 'XS_Tk__FontRankInfo_italic':
Tk.c:583:13: warning: format '%d' expects argument of type 'int', but argument 2 has type 'STRLEN' {aka 'long unsigned int'} [-Wformat=]
       croak("ST(0) too small (%d) for p LangFontInfo * (%d)",sz,sizeof(*p));
             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ~~
Tk.c:583:13: warning: format '%d' expects argument of type 'int', but argument 3 has type 'long unsigned int' [-Wformat=]
```