### PR TITLE
Allow mousewheel to scroll horizontal scrollbars on X11

### DIFF
--- a/Scrollbar/Scrollbar.pm
+++ b/Scrollbar/Scrollbar.pm
@@ -66,14 +66,13 @@ sub ClassInit
  $mw->bind($class, '<Next>',          ['ScrlByPages','hv', 1]);
 
  # X11 mousewheel - honour for horizontal too.
- $mw->bind($class, '<4>',             ['ScrlByUnits','hv',-5]);
- $mw->bind($class, '<5>',             ['ScrlByUnits','hv', 5]);
+ $mw->bind($class, '<Shift-4>',       ['ScrlByUnits','hv',-5]);
+ $mw->bind($class, '<Shift-5>',       ['ScrlByUnits','hv', 5]);
+ $mw->bind($class, '<Button-6>',      ['ScrlByUnits','hv',-5]);
+ $mw->bind($class, '<Button-7>',      ['ScrlByUnits','hv', 5]);
 
  $mw->bind($class, '<Home>',          ['ScrlToPos', 0]);
  $mw->bind($class, '<End>',           ['ScrlToPos', 1]);
-
- $mw->bind($class, '<4>',             ['ScrlByUnits','v',-3]);
- $mw->bind($class, '<5>',             ['ScrlByUnits','v', 3]);
 
  return $class;
 


### PR DESCRIPTION
(Windows is unaffected by this change)

Requires horizontal scrolling or shift+vertical scrolling, which more closely matches upstream Tcl/Tk behavior ([as of 8.5.15; see scrlbar.tcl](https://github.com/tcltk/tk/commit/3a394d4f68cc5b7a4cd940399a0d6666eb82422c#diff-67f959f4fab9be54005bc07317c94633R159))

Fixes RT #130109: https://rt.cpan.org/Ticket/Display.html?id=130109

Acked-by: @thefatphil