### PR TITLE
Fix RT #102648

### DIFF
--- a/pTk/mTk/generic/tkEntry.c
+++ b/pTk/mTk/generic/tkEntry.c
@@ -3450,16 +3450,21 @@ EntryValidateChange(entryPtr, change, new, index, type)
 
     if (entryPtr->validateCmd == NULL ||
 	entryPtr->validate == VALIDATE_NONE) {
+        if (entryPtr->flags & VALIDATING) {
+            entryPtr->flags |= VALIDATE_ABORT;
+        }
 	return (varValidate ? TCL_ERROR : TCL_OK);
     }
 
     /*
-     * If we're already validating, then we're hitting a loop condition
-     * Return and set validate to 0 to disallow further validations
-     * and prevent current validation from finishing
+     * If we're already validating, then we're hitting a loop condition. Set
+     * validate to none to disallow further validations, arrange for flags
+     * to prevent current validation from finishing, and return.
      */
+
     if (entryPtr->flags & VALIDATING) {
 	entryPtr->validate = VALIDATE_NONE;
+        entryPtr->flags |= VALIDATE_ABORT;
 	return (varValidate ? TCL_ERROR : TCL_OK);
     }
 


### PR DESCRIPTION
Backported fix for [RT #102648](https://rt.cpan.org/Ticket/Display.html?id=102648) which will appear in Tcl/Tk 8.6.11 (https://core.tcl-lang.org/tk/info/de3c5d235c):

> Fix [[40e4bf6198]](https://core.tcl-lang.org/tk/info/40e4bf6198): Entry/spinbox: double free when textvariable set in validatecommand script.
