### PR TITLE
Better operation on "perl in space"

### DIFF
--- a/Tk/MMtry.pm
+++ b/Tk/MMtry.pm
@@ -20,9 +20,9 @@ my $stderr_too = ($^O eq 'MSWin32') ? '' : '2>&1';
 sub try_compile
 {
  my ($file,$inc,$lib,$def)  = @_;
- $inc = [] unless $inc;
- $lib = [] unless $lib;
- $def = [] unless $def;
+ $inc ||= [];
+ $lib ||= [];
+ $def ||= [];
  my $stderr_too = $VERBOSE ? '' : $stderr_too;
  my $out   = basename($file,'.c').$Config{'exe_ext'};
  warn "Test Compiling $file\n";
@@ -36,9 +36,9 @@ sub try_compile
 sub try_run
 {
  my ($file,$inc,$lib,$def)  = @_;
- $inc = [] unless $inc;
- $lib = [] unless $lib;
- $def = [] unless $def;
+ $inc ||= [];
+ $lib ||= [];
+ $def ||= [];
  my $stderr_too = $VERBOSE ? '' : $stderr_too;
  my $out   = basename($file,'.c').$Config{'exe_ext'};
  warn "Test Compile/Run $file\n";

--- a/Tk/MMutil.pm
+++ b/Tk/MMutil.pm
@@ -7,6 +7,7 @@ use Cwd;
 use Config;
 use Carp;
 use File::Basename;
+use File::Spec::Functions qw(abs2rel);
 
 use vars qw($VERSION);
 $VERSION = '4.026';
@@ -401,8 +402,8 @@ sub makefile
 {
  my $self = shift;
  my $str  = $self->MM::makefile;
- my $mm = findINC('Tk/MMutil.pm');
- my $cf = findINC('Tk/Config.pm');
+ my $mm = abs2rel findINC('Tk/MMutil.pm');
+ my $cf = abs2rel findINC('Tk/Config.pm');
  $str =~ s/(\$\(CONFIGDEP\))/$1 $cf $mm/;
  $str =~ s/\$\(OBJECT\)\s*:.*\n//;
  return $str;


### PR DESCRIPTION
When Perl is installed in a directory with a space in it, the `makefile` function adds absolute paths (with spaces in) to the prerequisites for `$(CONFIGDEP)`. This means gmake cannot parse it so the build fails. Changing those absolute paths to relative ones eliminates that problem. (Although it's now failing because of a PNG error, which I'll look at now).