### PR TITLE
myConfig: add ability to define HAVE_INTTYPES_H

### DIFF
--- a/myConfig
+++ b/myConfig
@@ -66,6 +66,7 @@ $macro[1]->{WINARCH} = $win_arch;
 #
 
 $define{'USE_PROTOTYPE'} = 1     if ($Config{'prototype'});
+$define{'HAVE_INTTYPES_H'} = 1   if ($Config{'i_inttypes'});
 $define{'HAVE_UNISTD_H'} = 1     if ($Config{'i_unistd'});
 $define{'HAVE_SYS_SELECT_H'} = 1 if ($Config{'i_sysselct'});
 $define{'NO_STDLIB_H'} = 1       unless ($Config{'i_stdlib'});


### PR DESCRIPTION
The effect of this is that the installed tkConfig.h may contain `#define HAVE_INTTYPES_H 1`, which extensions can check before including <inttypes.h>.

Specifically, I would like to see if there is a way to use `intptr_t` and `uintptr_t` (from <inttypes.h>) in Tk::TableMatrix to resolve some compiler warnings using the approach common in newer Tcl/Tk C code: see asb-capfan/Tk-TableMatrix#3. But I would also need to figure out how to check for `intptr_t`/`uintptr_t`, as these types are not mandatory for inttypes.h, and Config.pm does not seem to already check for them.