### PR TITLE
Do not define "ControlMask" as a macro in pTk/mTk/xlib/X11/X.h

### DIFF
--- a/Xlib/X/X.xs
+++ b/Xlib/X/X.xs
@@ -614,8 +614,8 @@ int arg;
 	    goto not_there;
 #endif
 	if (strEQ(name, "ControlMask"))
-#ifdef ControlMask
-	    return ControlMask;
+#ifdef ControlMask2
+	    return ControlMask2;
 #else
 	    goto not_there;
 #endif

--- a/pTk/mTk/generic/tkBind.c
+++ b/pTk/mTk/generic/tkBind.c
@@ -421,7 +421,7 @@ typedef struct {
 #define MULT_CLICKS	7
 
 static ModInfo modArray[] = {
-    {"Control",		ControlMask,	0},
+    {"Control",		ControlMask2,	0},
     {"Shift",		ShiftMask,	0},
     {"Lock",		LockMask,	0},
     {"Meta",		META_MASK,	0},

--- a/pTk/mTk/win/tkWinKey.c
+++ b/pTk/mTk/win/tkWinKey.c
@@ -217,7 +217,7 @@ KeycodeToKeysym(keycode, state, noascii)
     memset(keys, 0, 256);
     if (state & ShiftMask)
         keys[VK_SHIFT] = 0x80;
-    if (state & ControlMask)
+    if (state & ControlMask2)
 	keys[VK_CONTROL] = 0x80;
     if (state & Mod2Mask)
 	keys[VK_MENU] = 0x80;
@@ -395,8 +395,8 @@ TkpGetKeySym(dispPtr, eventPtr)
      * is no keysym defined, try without the modifiers.
      */
 
-    if ((sym == NoSymbol) && ((state & ControlMask) || (state & Mod2Mask))) {
-        state &=  ~(ControlMask | Mod2Mask);
+    if ((sym == NoSymbol) && ((state & ControlMask2) || (state & Mod2Mask))) {
+        state &=  ~(ControlMask2 | Mod2Mask);
         sym = KeycodeToKeysym(eventPtr->xkey.keycode, state, 0);
     }
     if ((sym == NoSymbol) && (state & ShiftMask)) {
@@ -578,7 +578,7 @@ TkpSetKeycodeAndState(tkwin, keySym, eventPtr)
             if (shift & 1)
                 eventPtr->xkey.state |= ShiftMask;
             if (shift & 2)
-                eventPtr->xkey.state |= ControlMask;
+                eventPtr->xkey.state |= ControlMask2;
             if (shift & 4)
                 eventPtr->xkey.state |= Mod2Mask;
             eventPtr->xkey.keycode = (KeyCode) (result & 0xff);

--- a/pTk/mTk/win/tkWinPointer.c
+++ b/pTk/mTk/win/tkWinPointer.c
@@ -60,7 +60,7 @@ TkWinGetModifierState()
 	state |= ShiftMask;
     }
     if (GetKeyState(VK_CONTROL) & 0x8000) {
-	state |= ControlMask;
+	state |= ControlMask2;
     }
     if (GetKeyState(VK_MENU) & 0x8000) {
 	state |= ALT_MASK;

--- a/pTk/mTk/win/tkWinX.c
+++ b/pTk/mTk/win/tkWinX.c
@@ -1247,7 +1247,7 @@ GetState(message, wParam, lParam)
 		mask = ShiftMask;
 		break;
 	    case VK_CONTROL:
-		mask = ControlMask;
+		mask = ControlMask2;
 		break;
 	    case VK_MENU:
 		mask = ALT_MASK;
@@ -1666,7 +1666,7 @@ TkWinResendEvent(wndproc, hwnd, eventPtr)
 	if (eventPtr->xbutton.state & ShiftMask) {
 	    wparam |= MK_SHIFT;
 	}
-	if (eventPtr->xbutton.state & ControlMask) {
+	if (eventPtr->xbutton.state & ControlMask2) {
 	    wparam |= MK_CONTROL;
 	}
 	lparam = MAKELPARAM((short) eventPtr->xbutton.x,

--- a/pTk/mTk/xlib/X11/X.h
+++ b/pTk/mTk/xlib/X11/X.h
@@ -179,7 +179,10 @@ are reserved in the protocol for errors and replies. */
 
 #define ShiftMask		(1<<0)
 #define LockMask		(1<<1)
-#define ControlMask		(1<<2)
+ /* Use ControlMask2 due to conflict with ControlMask defined in processthreadsapi.h
+	for Win32, see https://github.com/eserte/perl-tk/issues/87 for more information
+ */
+#define ControlMask2	(1<<2)
 #define Mod1Mask		(1<<3)
 #define Mod2Mask		(1<<4)
 #define Mod3Mask		(1<<5)


### PR DESCRIPTION
The name "ControlMask" is already defined in header `processthreadsapi.h` (pulled in by `windows.h` for platform Win32). Instead use "ControlMask2". This fixes issue #87.