### PR TITLE
Avoid implicit ints and implicit function declarations

### DIFF
--- a/config/signedchar.c
+++ b/config/signedchar.c
@@ -1,4 +1,4 @@
-main()
+int main(void)
 {
  signed char x = 'a';
  return (x - 'a');

--- a/config/unsigned.c
+++ b/config/unsigned.c
@@ -1,15 +1,16 @@
+#include <stdio.h>
 int main()
 {
  char x[] = "\377";
  if (x[0] > 0)
   {
    printf("char is unsigned type\n");
-   exit(0);
+   return 0;
   }
  else
   {
    printf("char is signed type\n");
-   exit(1);
+   return 1;
   }
 }
 

--- a/pTk/config/Hstrdup.c
+++ b/pTk/config/Hstrdup.c
@@ -6,7 +6,7 @@ int main()
 {char *e;
  char *p = strdup(STRING);
  if (!p || strcmp(p,STRING))
-  exit(1);
+  return 1;
  return 0;
 }
 

--- a/pTk/config/Hstrtoul.c
+++ b/pTk/config/Hstrtoul.c
@@ -1,4 +1,5 @@
 #include <stdlib.h>
+#include <string.h>
 
 int main()
 {char *e;

--- a/pTk/mTk/generic/tkEvent.c
+++ b/pTk/mTk/generic/tkEvent.c
@@ -1153,6 +1153,7 @@ TkEventDeadWindow(winPtr)
 Time
 TkCurrentTime(dispPtr, fallbackCurrent)
     TkDisplay *dispPtr;		/* Display for which the time is desired. */
+    int fallbackCurrent;
 {
     register XEvent *eventPtr;
     ThreadSpecificData *tsdPtr = (ThreadSpecificData *)

--- a/pTk/mTk/generic/tkImage.c
+++ b/pTk/mTk/generic/tkImage.c
@@ -1083,6 +1083,8 @@ int x;
 int y;
 int width;
 int height;
+int imgWidth;
+int imgHeight;
 {
     Tk_Tile tile = (Tk_Tile) clientData;
     Tk_TileChange *handler;


### PR DESCRIPTION
These language features have been removed from C in 1999.  Future compilers are likely to stop accepting these constructs by default.

Related to:

* https://fedoraproject.org/wiki/Changes/PortingToModernC
* https://fedoraproject.org/wiki/Toolchain/PortingToModernC
