### PR TITLE
jpeg: fix build with clang 16

### DIFF
--- a/JPEG/jpeg/configure
+++ b/JPEG/jpeg/configure
@@ -623,7 +623,7 @@ cross_compiling=$ac_cv_prog_cc_cross
 cat > conftest.$ac_ext <<EOF
 #line 625 "configure"
 #include "confdefs.h"
-main(){return(0);}
+int main(){return(0);}
 EOF
 if { (eval echo configure:629: \"$ac_link\") 1>&5; (eval $ac_link) 2>&5; } && test -s conftest; then
   ac_cv_prog_cc_works=yes


### PR DESCRIPTION
The jpeg `configure` script fails to detect clang as a functioning C compiler because it uses a test with a `main` that returns an implicit `int`, which results in an error with clang 16.

From https://github.com/NixOS/nixpkgs/pull/253730

Cc: @reckenrode