### PR TITLE
pregcomp2.c: Avoid using incompatible pointer type

### DIFF
--- a/config/pregcomp2.c
+++ b/config/pregcomp2.c
@@ -4,5 +4,5 @@
 
 int main() {
     SV* sv = newSViv(0);
-    regexp* rx = pregcomp(sv, 0);
+    void* rx = pregcomp(sv, 0);
 }


### PR DESCRIPTION
See https://github.com/eserte/perl-tk/issues/98#issuecomment-1948125587: Newer compilers may have `-Werror=incompatible-pointer-types` by default. Since pregcomp2.c does not dereference the result of `pregcomp2()`, the result can be assigned to `void *` instead. There is already the regexp511.c configuration test to decide whether to use `REGEXP *` instead of `regexp *`, but that test is run after pregcomp2.c.