### PR TITLE
Avoid using incompatible pointer type for `old_warn`

### DIFF
--- a/Event/Event.xs
+++ b/Event/Event.xs
@@ -1532,7 +1532,7 @@ PROTOTYPES: DISABLE
 BOOT:
  {
 #ifdef pWARN_NONE
-  SV *old_warn = PL_curcop->cop_warnings;
+  void *old_warn = PL_curcop->cop_warnings;
   PL_curcop->cop_warnings = pWARN_NONE;
 #endif
   newXS("Tk::Event::INIT", XS_Tk__Event_INIT, file);

--- a/tkGlue.c
+++ b/tkGlue.c
@@ -5543,13 +5543,8 @@ _((pTHX))
  char *XEventMethods = "abcdfhkmopstvwxyABDEKNRSTWXY#";
  char buf[128];
  CV *cv;
-#if PERL_REVISION > 5 || (PERL_REVISION == 5 && PERL_VERSION >= 9)
-#define COP_WARNINGS_TYPE STRLEN*
-#else
-#define COP_WARNINGS_TYPE SV*
-#endif
 #ifdef pWARN_NONE
- COP_WARNINGS_TYPE old_warn = PL_curcop->cop_warnings;
+ void *old_warn = PL_curcop->cop_warnings;
  PL_curcop->cop_warnings = pWARN_NONE;
 #endif
 


### PR DESCRIPTION
See https://github.com/eserte/perl-tk/issues/98#issuecomment-1944054296: `PL_curcop->cop_warnings` previously had type `SV *`, then `STRLEN *`, and now `char *` as of Perl 5.37.6.  Since `old_warn` is only used to temporarily hold the value from `PL_curcop->cop_warnings` without dereferencing it, `old_warn` can be declared as `void *` instead regardless of Perl 5 version.