### PR TITLE
Eliminate most 'deprecated declarations' warnings

### DIFF
--- a/Event/Event.xs
+++ b/Event/Event.xs
@@ -1151,7 +1151,7 @@ XS(XS_Tk__Callback_Call)
  int count;
  SV *cb = ST(0);
  SV *err;
- int wantarray = GIMME;
+ int wantarray = GIMME_V;
  if (!items)
   {
    croak("No arguments");
@@ -1168,7 +1168,7 @@ XS(XS_Tk__Callback_Call)
   }
  PUTBACK;
 
- count = LangCallCallback(cb,GIMME|G_EVAL);
+ count = LangCallCallback(cb,GIMME_V|G_EVAL);
  SPAGAIN;
 
  err = ERRSV;

--- a/pTk/mTk/unix/tkUnixKey.c
+++ b/pTk/mTk/unix/tkUnixKey.c
@@ -178,7 +178,7 @@ TkpGetString(winPtr, eventPtr, dsPtr)
 /*
  * When mapping from a keysym to a keycode, need
  * information about the modifier state that should be used
- * so that when they call XKeycodeToKeysym taking into
+ * so that when they call XkbKeycodeToKeysym taking into
  * account the xkey.state, they will get back the original
  * keysym.
  */
@@ -202,7 +202,7 @@ TkpSetKeycodeAndState(tkwin, keySym, eventPtr)
     }
     if (keycode != 0) {
 	for (state = 0; state < 4; state++) {
-	    if (XKeycodeToKeysym(display, keycode, state) == keySym) {
+	    if (XkbKeycodeToKeysym(display, keycode, state) == keySym) {
 		if (state & 1) {
 		    eventPtr->xkey.state |= ShiftMask;
 		}
@@ -271,7 +271,7 @@ TkpGetKeySym(dispPtr, eventPtr)
 	    && (eventPtr->xkey.state & LockMask))) {
 	index += 1;
     }
-    sym = XKeycodeToKeysym(dispPtr->display, eventPtr->xkey.keycode, index);
+    sym = XkbKeycodeToKeysym(dispPtr->display, eventPtr->xkey.keycode, index);
 
     /*
      * Special handling:  if the key was shifted because of Lock, but
@@ -286,7 +286,7 @@ TkpGetKeySym(dispPtr, eventPtr)
 		|| ((sym >= XK_Agrave) && (sym <= XK_Odiaeresis))
 		|| ((sym >= XK_Ooblique) && (sym <= XK_Thorn)))) {
 	    index &= ~1;
-	    sym = XKeycodeToKeysym(dispPtr->display, eventPtr->xkey.keycode,
+	    sym = XkbKeycodeToKeysym(dispPtr->display, eventPtr->xkey.keycode,
 		    index);
 	}
     }
@@ -297,7 +297,7 @@ TkpGetKeySym(dispPtr, eventPtr)
      */
 
     if ((index & 1) && (sym == NoSymbol)) {
-	sym = XKeycodeToKeysym(dispPtr->display, eventPtr->xkey.keycode,
+	sym = XkbKeycodeToKeysym(dispPtr->display, eventPtr->xkey.keycode,
 		index & ~1);
     }
     return sym;
@@ -348,7 +348,7 @@ TkpInitKeymapInfo(dispPtr)
 	if (*codePtr == 0) {
 	    continue;
 	}
-	keysym = XKeycodeToKeysym(dispPtr->display, *codePtr, 0);
+	keysym = XkbKeycodeToKeysym(dispPtr->display, *codePtr, 0);
 	if (keysym == XK_Shift_Lock) {
 	    dispPtr->lockUsage = LU_SHIFT;
 	    break;
@@ -374,7 +374,7 @@ TkpInitKeymapInfo(dispPtr)
 	if (*codePtr == 0) {
 	    continue;
 	}
-	keysym = XKeycodeToKeysym(dispPtr->display, *codePtr, 0);
+	keysym = XkbKeycodeToKeysym(dispPtr->display, *codePtr, 0);
 	if (keysym == XK_Mode_switch) {
 	    dispPtr->modeModMask |= ShiftMask << (i/modMapPtr->max_keypermod);
 	}


### PR DESCRIPTION
If I build Tk-804.036 against a Perl executable built on Linux and compiled with `gcc-13` (currently the most recent version of `gcc` against which Tk's `make` will complete), I get the following count of build-time warnings:
```
$ report-build-warnings 804.036-0-gcc-13.make.output.txt 
File:  804.036-0-gcc-13.make.output.txt

  Wdeprecated-declarations                   9
  Wdiscarded-qualifiers                      1
  Wformat-overflow=                          5
  Wimplicit-int                              3
  Wincompatible-pointer-types                7
  Wint-to-pointer-cast                      42
  Wpointer-to-int-cast                      25
  Wstringop-overflow=                        1
```
The patches in this pull request, when applied will reduce the number of `Wdeprecated-declarations` warnings from 9 to 1.
```
$ report-build-warnings 07ef24a882.gcc13.make.output.txt 
File:  07ef24a882.gcc13.make.output.txt

  Wdeprecated-declarations                   1
  Wdiscarded-qualifiers                      1
  Wformat-overflow=                          5
  Wimplicit-function-declaration             1
  Wimplicit-int                              3
  Wincompatible-pointer-types                7
  Wint-to-pointer-cast                      42
  Wpointer-to-int-cast                      25
  Wstringop-overflow=                        1
```
For changes in tkUnixKey.c, consult DDG search for "XKeycodeToKeysym is deprecated".

For changes in Event/Event.xs, see `perldoc perl5380delta`.


The one remaining `Wdeprecated-declarations` build-time warning appears during `make` like this:
```
In file included from Xlib_f.c:17:
Xlib.t:334:1: warning: ‘XKeycodeToKeysym’ is deprecated [-Wdeprecated-declarations]
  334 | VFUNC(KeySym,XKeycodeToKeysym,V_XKeycodeToKeysym,_ANSI_ARGS_((Display *, unsigned int, int)))
      | ^~~~~
```
And here's the relevant source code in pTk/Xlib.t:
```
333 #ifndef XKeycodeToKeysym
334 VFUNC(KeySym,XKeycodeToKeysym,V_XKeycodeToKeysym,_ANSI_ARGS_((Display *, unsigned int, int)))
335 #endif /* #ifndef XKeycodeToKeysym */
```
A simple search-and-replace, `XKeycodeToKeysym` -> `XkbKeycodeToKeysym`, did not compile, so I left this instance alone.

